### PR TITLE
fixed the wrong spliter.

### DIFF
--- a/GCP-Cost-Dashboard-Stack.yaml
+++ b/GCP-Cost-Dashboard-Stack.yaml
@@ -224,7 +224,7 @@ Resources:
               
               # Parse billing table names
               billing_tables = os.environ.get('GCPFullTableName')
-              vars['gcp_billing_full_table_names'] = billing_tables.split(',') if billing_tables else []
+              vars['gcp_billing_full_table_names'] = billing_tables.split(';') if billing_tables else []
               
               # Parse pricing table name
               vars['gcp_pricing_full_table_name'] = os.environ.get('GCPPricingFullTableName')
@@ -256,7 +256,7 @@ Resources:
               if not focus_tables or focus_tables.strip() == '':
                   return []
               
-              return [table.strip() for table in focus_tables.split(',') 
+              return [table.strip() for table in focus_tables.split(';') 
                       if validate_table_name(table.strip(), is_focus=True)]
           
           def create_glue_job_trigger(job_names, env_vars):


### PR DESCRIPTION
*Issue #, if available:*  Fix buggy spliter logic for GCP Billing Full Table Id List  and GCP Focus Full Table Id List. The existing logic was creating wrong failing glue jobs when there is use case of aggregating multiple billing export tables.
*Description of changes:*
The existing splitter logic was using "," for splitting the table which seems to be a bug as the GCPGlueGenerator lambda function was getting the "GCPFocusFullTableName" and "GCPFullTableName" injected as env parameter array with ";" as a delimeter.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
